### PR TITLE
tensorflow/travis fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,19 +4,17 @@ cache: pip
 
 python:
  - "2.7"
+ - "3.6"
 
 install:
-  - pip install -r requirements.txt
+  - pip install Coverage pytest pytest-cov coveralls
+  - pip install -r ImageCropper/requirements.txt
+# - pip install -r parking_classifier/requirements3.txt
 
 before_install:
  - sudo apt-get update
- - ls -la .
- - exit 1
- #- ./ParkingSpaceApp/ImageCropper/venv/bin/activate
- - pip install Coverage pytest pytest-cov coveralls
- #- pip install -r parking_classifier/requirements3.txt
- #- pip install -r ./ParkingSpaceApp/ImageCropper/requirements.txt
-
+ - ImageCropper/venv/bin/activate
+ 
 script: 
  - cd ImageCropper
  - cat comvo_1.h5.part* > comvo_1.h5

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,33 @@
 
 language: python
+
+# this supposedly caches your python dependencies between travis builds.
+# i've no idea if it *actually* works...
 cache: pip
 
+# i haven't tested whether 2.7 does indeed work, yet.
+# seems best to just run the python version you're using locally, though.
 python:
- - "2.7"
- - "3.6"
+ - "3.5"
 
+# i moved your dependency installs into the install step.
+# ultimately, this makes no difference, it's just neater...
 install:
   - pip install Coverage pytest pytest-cov coveralls
-  #- pip install -r ImageCropper/requirements.txt
-  - pip install -r parking_classifier/requirements3.txt
+  - pip install -r parking_classifier/requirements-without-tensorflow-gpu.txt
 
 before_install:
+ 
+ # this apt update might not be required, i haven't tested
  - sudo apt-get update
+ 
+ # run the `chmod` command below locally once, then commit the
+ # file, then remove this line from this file
  - chmod +x ImageCropper/venv/bin/activate
+ 
+ # i don't know whether it'll work without activating your venv.
+ # much like using the same python version you're using locally, it just seemed like a good idea.
+ # try testing without.
  - ImageCropper/venv/bin/activate
  
 script: 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,10 @@ python:
 
 before_install:
  - sudo apt-get update
- - sudo ldconfig /usr/local/cuda/lib64
- - ls -la /usr/local/cuda
- - ls -la /opt/cuda
- - exit 10
+ - ./ParkingSpaceApp/ImageCropper/venv/bin/activate
  - pip install Coverage pytest pytest-cov coveralls
- - pip install -r parking_classifier/requirements3.txt
+ #- pip install -r parking_classifier/requirements3.txt
+ - pip install -r ./ParkingSpaceApp/ImageCropper/requirements.txt
 
 script: 
  - cd ImageCropper

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,21 @@
 
 language: python
+cache: pip
 
 python:
  - "2.7"
 
+install:
+  - pip install -r requirements.txt
+
 before_install:
  - sudo apt-get update
- - ./ParkingSpaceApp/ImageCropper/venv/bin/activate
+ - ls -la .
+ - exit 1
+ #- ./ParkingSpaceApp/ImageCropper/venv/bin/activate
  - pip install Coverage pytest pytest-cov coveralls
  #- pip install -r parking_classifier/requirements3.txt
- - pip install -r ./ParkingSpaceApp/ImageCropper/requirements.txt
+ #- pip install -r ./ParkingSpaceApp/ImageCropper/requirements.txt
 
 script: 
  - cd ImageCropper

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ python:
 
 install:
   - pip install Coverage pytest pytest-cov coveralls
-  - pip install -r ImageCropper/requirements.txt
-# - pip install -r parking_classifier/requirements3.txt
+  #- pip install -r ImageCropper/requirements.txt
+  - pip install -r parking_classifier/requirements3.txt
 
 before_install:
  - sudo apt-get update

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
  - sudo ldconfig /usr/local/cuda/lib64
  - ls -la /usr/local/cuda
  - ls -la /opt/cuda
- - exit 1
+ - exit 10
  - pip install Coverage pytest pytest-cov coveralls
  - pip install -r parking_classifier/requirements3.txt
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,21 @@
+
 language: python
 
 python:
  - "2.7"
-before_install:
 
- - pip install Coverage
- - pip install pytest pytest-cov
- - pip install coveralls
- - sudo apt-get update 
- #- sudo -E apt install libopencv-dev 
- #- pip install opencv-python
-# - pip install tensorflow
- #- pip install keras
+before_install:
+ - sudo apt-get update
+ - sudo ldconfig /usr/local/cuda/lib64
+ - ls -la /usr/local/cuda
+ - ls -la /opt/cuda
+ - exit 1
+ - pip install Coverage pytest pytest-cov coveralls
  - pip install -r parking_classifier/requirements3.txt
- 
+
 script: 
  - cd ImageCropper
  - cat comvo_1.h5.part* > comvo_1.h5
- - py.test --cov=ImageCropper test_image.py/
+ - py.test --cov=ImageCropper test_image.py
  
 after_success: coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ install:
 
 before_install:
  - sudo apt-get update
+ - chmod +x ImageCropper/venv/bin/activate
  - ImageCropper/venv/bin/activate
  
 script: 

--- a/parking_classifier/requirements-without-tensorflow-gpu.txt
+++ b/parking_classifier/requirements-without-tensorflow-gpu.txt
@@ -1,0 +1,8 @@
+tensorflow
+tensorboard==1.0.0a6
+Keras==2.0.6
+numpy
+imagesize==0.7.1
+opencv-python==3.2.0.7
+pandas==0.20.1
+pytest==3.0.7

--- a/parking_classifier/requirements3.txt
+++ b/parking_classifier/requirements3.txt
@@ -1,6 +1,6 @@
 tensorflow
 tensorboard==1.0.0a6
-# tensorflow-gpu==1.2.1
+tensorflow-gpu==1.2.1
 Keras==2.0.6
 numpy
 imagesize==0.7.1

--- a/parking_classifier/requirements3.txt
+++ b/parking_classifier/requirements3.txt
@@ -1,6 +1,6 @@
 tensorflow
 tensorboard==1.0.0a6
-tensorflow-gpu==1.2.1
+# tensorflow-gpu==1.2.1
 Keras==2.0.6
 numpy
 imagesize==0.7.1


### PR DESCRIPTION
after a bunch of poking around i found that we just had to remove `tensorflow-gpu` when running on travis, which makes a lot of sense.

so i added a [new dependency manifest](https://github.com/skibz/ParkingSpaceApp/blob/travis-expr-1/parking_classifier/requirements-without-tensorflow-gpu.txt) that excludes `tensorflow-gpu`. then, when running unit tests in travis, we install dependencies using that file instead.

i also changed some of the build settings to try and make it consistent with your local development set-up. i could have gone one step further and made travis use ubuntu xenial (which is what tensorflow officially supports) but it all appears to be working 14.04, too, so no big deal.